### PR TITLE
fix: group check order

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
     --data "config.hosted_domain=mycompany.com" \
     --data "config.email_key=email" \
     --data "config.salt=b3253141ce67204b" \
+    --data "config.service_logout_url=https://iam.service/realm/logout" \
     --data "config.app_login_redirect_url=https://yourapplication.com/loggedin/dashboard" \
     --data "config.cookie_domain=.company.com" \
     --data "config.user_info_cache_enabled=false"
@@ -38,6 +39,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 | `config.email_key` 		  | | key to be checked for hosted domain, taken from userinfo endpoint |
 | `config.user_info_periodic_check` 		  | 60 | time in seconds between token checks |
 | `config.salt` 		  | b3253141ce67204b | salt for the user session token, must be 16 char alphanumeric |
+| `config.service_logout_url`         | | The URL for logouts in your IAM provider. Will be redirected to this URL when hitting urls ending in `/logout` |
 | `config.app_login_redirect_url` 		  | | Needed for Single Page Applications to redirect after initial authentication successful, otherwise a proxy request following initial authentication would redirect data directly to a users browser! |
 | `config.cookie_domain` 		  | | Specify the domain in which this cookie is valid for, realistically will need to match the gateway |
 | `config.user_info_cache_enabled` 		  | | This enables storing the userInfo in Kong local cache which enables sending the entire requested user information to the backend service upon every request, otherwise user info only comes back occasionally and backend api service providers are required to validate the EOAuth Cookie Session with cached user information within their logic |

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 | `config.cookie_domain` 		  | | Specify the domain in which this cookie is valid for, realistically will need to match the gateway |
 | `config.user_info_cache_enabled` 		  | | This enables storing the userInfo in Kong local cache which enables sending the entire requested user information to the backend service upon every request, otherwise user info only comes back occasionally and backend api service providers are required to validate the EOAuth Cookie Session with cached user information within their logic |
 | `config.realm`        | | (Optional) This value will be passed as `X-Oauth-realm` _if and only if_ it is included as part of the request URL. |
+| `config.allowed_roles`        | | (Optional) An array of roles, any of which should grant access to this route. This will be checked against the `groups` field from your OIDC providers userinfo endpoint. You _must_ make roles available as userinfo.groups for this to work, otherwise enabling this option will block all users as their roles will not be retrievable. |
 
-In addition to the `user_keys` will be added a `X-OAUTH-TOKEN` header with the access token of the provider.
+Data available from the userinfo endpoint and included in the `config.user_keys` section will be included as headers following the pattern `X-Oauth-{field}` to upstream services.
 
 NOTES:
 Ping Federate requires you to authorize a callback URL, all proxies have a standard call back route of:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 | `config.app_login_redirect_url` 		  | | Needed for Single Page Applications to redirect after initial authentication successful, otherwise a proxy request following initial authentication would redirect data directly to a users browser! |
 | `config.cookie_domain` 		  | | Specify the domain in which this cookie is valid for, realistically will need to match the gateway |
 | `config.user_info_cache_enabled` 		  | | This enables storing the userInfo in Kong local cache which enables sending the entire requested user information to the backend service upon every request, otherwise user info only comes back occasionally and backend api service providers are required to validate the EOAuth Cookie Session with cached user information within their logic |
+| `config.realm`        | | (Optional) This value will be passed as `X-Oauth-realm` _if and only if_ it is included as part of the request URL. |
 
 In addition to the `user_keys` will be added a `X-OAUTH-TOKEN` header with the access token of the provider.
 

--- a/kong-oidc-auth-0.1-4.rockspec
+++ b/kong-oidc-auth-0.1-4.rockspec
@@ -1,12 +1,12 @@
 package = "kong-oidc-auth"
-version = "0.1-3"
+version = "0.1-4"
 source = {
-   url = "git+https://github.com/Optum/kong-oidc-auth.git"
+   url = "git+https://github.com/eHealthAfrica/kong-oidc-auth.git"
 }
 description = {
    summary = "OpenID Connect authentication with Kong gateway",
-   detailed = [[Please refer to the documentation associated here: https://github.com/Optum/kong-oidc-auth ]],
-   homepage = "https://github.com/Optum/kong-oidc-auth",
+   detailed = [[Please refer to the documentation associated here: https://github.com/eHealthAfrica/kong-oidc-auth ]],
+   homepage = "https://github.com/eHealthAfrica/kong-oidc-auth",
    license = "Apache 2.0"
 }
 dependencies = {}

--- a/src/access.lua
+++ b/src/access.lua
@@ -178,7 +178,7 @@ function _M.run(conf)
 	elseif pl_stringx.endswith(path_prefix, "/oauth2/callback") then --We are in the callback of our proxy
 	  callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix
       -- handle_callback(conf, callback_url)
-      handle_callback(conf, path_prefix:split('/oauth2/callback')[0])
+      handle_callback(conf, pl_stringx.split(path_prefix, '/oauth2/callback')[0])
 	else
 	  callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix .. "/oauth2/callback"
 	end

--- a/src/access.lua
+++ b/src/access.lua
@@ -207,6 +207,7 @@ function _M.run(conf)
 		      ngx.header["X-Oauth-".. key] = userInfo[key]
 		      ngx.req.set_header("X-Oauth-".. key, userInfo[key])
 		  end
+		      ngx.req.set_header("X-Oauth-Token", access_token)
 		      ngx.header["X-Oauth-Token"] = access_token	
 		  return
 		end
@@ -229,6 +230,7 @@ function _M.run(conf)
 			ngx.header["X-Oauth-".. key] = json[key]
 			ngx.req.set_header("X-Oauth-".. key, json[key])
 		    end
+		    ngx.req.set_header("X-Oauth-Token", access_token)
 		    ngx.header["X-Oauth-Token"] = access_token
 
 		    if type(ngx.header["Set-Cookie"]) == "table" then

--- a/src/access.lua
+++ b/src/access.lua
@@ -224,8 +224,11 @@ function _M.run(conf)
 		      ngx.header["X-Oauth-".. key] = userInfo[key]
 		      ngx.req.set_header("X-Oauth-".. key, userInfo[key])
 		  end
-		      ngx.req.set_header("X-Oauth-Token", access_token)
-		      ngx.header["X-Oauth-Token"] = access_token
+      if (conf.realm ~= "" and (pl_stringx.count(ngx.var.request_uri, conf.realm) > 0)) then -- inject realm name into headers
+       ngx.header["X-Oauth-realm"] = conf.realm
+      end
+      ngx.req.set_header("X-Oauth-Token", access_token)
+      ngx.header["X-Oauth-Token"] = access_token
 		  return
 		end
   end
@@ -247,6 +250,9 @@ function _M.run(conf)
     			ngx.header["X-Oauth-".. key] = json[key]
     			ngx.req.set_header("X-Oauth-".. key, json[key])
 		    end
+        if (conf.realm ~= "" and (pl_stringx.count(ngx.var.request_uri, conf.realm) > 0)) then -- inject realm name into headers
+          ngx.header["X-Oauth-realm"] = conf.realm
+        end
 		    ngx.req.set_header("X-Oauth-Token", access_token)
 		    ngx.header["X-Oauth-Token"] = access_token
 

--- a/src/access.lua
+++ b/src/access.lua
@@ -80,17 +80,20 @@ end
 -- Logout Handling
 function  handle_logout(encrypted_token, conf)
    --Terminate the Cookie
+   local redirect_url = string.format("%s?redirect_uri=%s", conf.service_logout_url, conf.app_login_redirect_url)
    if type(ngx.header["Set-Cookie"]) == "table" then
 	ngx.header["Set-Cookie"] = { "EOAuthToken=;Path=/;Expires=Thu, Jan 01 1970 00:00:00 UTC;Max-Age=0;HttpOnly" .. cookieDomain, unpack(ngx.header["Set-Cookie"]) }
    else
         ngx.header["Set-Cookie"] = { "EOAuthToken=;Path=/;Expires=Thu, Jan 01 1970 00:00:00 UTC;Max-Age=0;HttpOnly" .. cookieDomain, ngx.header["Set-Cookie"] }
    end
-   
+   -- Remove session
    if conf.user_info_cache_enabled then
       singletons.cache:invalidate(encrypted_token)
    end
-   
-   return kong.response.exit(200)
+   -- Redirect to IAM service logout
+   return kong.response.exit(301, { message = "Logged Out" }, {
+        ["Location:"] = redirect_url
+    })
 end
 
 -- Callback Handling

--- a/src/access.lua
+++ b/src/access.lua
@@ -177,7 +177,8 @@ function _M.run(conf)
 	  callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix .. "/oauth2/callback"
 	elseif pl_stringx.endswith(path_prefix, "/oauth2/callback") then --We are in the callback of our proxy
 	  callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix
-	  handle_callback(conf, callback_url)
+      -- handle_callback(conf, callback_url)
+      handle_callback(conf, path_prefix:split('/oauth2/callback')[0])
 	else
 	  callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix .. "/oauth2/callback"
 	end

--- a/src/access.lua
+++ b/src/access.lua
@@ -134,15 +134,6 @@ function  handle_callback( conf, callback_url )
         else
     	   ngx.header["Set-Cookie"] = { "EOAuthToken=" .. encode_token(access_token, conf) .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, ngx.header["Set-Cookie"] }
         end
-    	
-    	--Support redirection back to Application Loggedin Dashboard for subsequent transactions
-    	-- if conf.app_login_redirect_url ~= "" then
-    	--    return ngx.redirect(conf.app_login_redirect_url)
-    	-- end
-    	if redirect_url ~= "" then
-            return ngx.redirect(redirect_url)
-        end
-
 
         -- Support redirection back to Kong if necessary
         local redirect_back = ngx.var.cookie_EOAuthRedirectBack
@@ -177,8 +168,10 @@ function _M.run(conf)
 	  callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix .. "/oauth2/callback"
 	elseif pl_stringx.endswith(path_prefix, "/oauth2/callback") then --We are in the callback of our proxy
 	  callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix
-      -- handle_callback(conf, callback_url)
-      handle_callback(conf, pl_stringx.split(path_prefix, '/oauth2/callback')[0])
+    -- ngx.log(ngx.ERR, pl_stringx.split(path_prefix, '/oauth2/callback'))
+    handle_callback(conf, callback_url)
+    -- ngx.log(ngx.ERR, "Could not retrieve UserInfo: ", err)
+    -- handle_callback(conf, pl_stringx.split(path_prefix, '/oauth2/callback')[0])
 	else
 	  callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix .. "/oauth2/callback"
 	end

--- a/src/access.lua
+++ b/src/access.lua
@@ -129,17 +129,21 @@ function  handle_callback( conf, callback_url )
             return kong.response.exit(oidc_error.status, { message = oidc_error.message })
         end
 
-	if type(ngx.header["Set-Cookie"]) == "table" then
-	   ngx.header["Set-Cookie"] = { "EOAuthToken=" .. encode_token(access_token, conf) .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, unpack(ngx.header["Set-Cookie"]) }
+    	if type(ngx.header["Set-Cookie"]) == "table" then
+    	   ngx.header["Set-Cookie"] = { "EOAuthToken=" .. encode_token(access_token, conf) .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, unpack(ngx.header["Set-Cookie"]) }
         else
-	   ngx.header["Set-Cookie"] = { "EOAuthToken=" .. encode_token(access_token, conf) .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, ngx.header["Set-Cookie"] }
+    	   ngx.header["Set-Cookie"] = { "EOAuthToken=" .. encode_token(access_token, conf) .. ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + 1800) .. ";Max-Age=1800;HttpOnly" .. cookieDomain, ngx.header["Set-Cookie"] }
         end
-	
-	--Support redirection back to Application Loggedin Dashboard for subsequent transactions
-	if conf.app_login_redirect_url ~= "" then
-	   return ngx.redirect(conf.app_login_redirect_url)
-	end
-	
+    	
+    	--Support redirection back to Application Loggedin Dashboard for subsequent transactions
+    	-- if conf.app_login_redirect_url ~= "" then
+    	--    return ngx.redirect(conf.app_login_redirect_url)
+    	-- end
+    	if redirect_url ~= "" then
+            return ngx.redirect(redirect_url)
+        end
+
+
         -- Support redirection back to Kong if necessary
         local redirect_back = ngx.var.cookie_EOAuthRedirectBack
 		
@@ -147,7 +151,7 @@ function  handle_callback( conf, callback_url )
             return ngx.redirect(redirect_back) --Should always land here if no custom Loggedin page defined!
         else
           --return redirect_to_auth(conf, callback_url)
-	    return
+	       return
         end
     else
         oidc_error = {status = ngx.HTTP_UNAUTHORIZED, message = "User has denied access to the resources"}

--- a/src/access.lua
+++ b/src/access.lua
@@ -91,9 +91,8 @@ function  handle_logout(encrypted_token, conf)
       singletons.cache:invalidate(encrypted_token)
    end
    -- Redirect to IAM service logout
-   return kong.response.exit(301, { message = "Logged Out" }, {
-        ["Location:"] = redirect_url
-    })
+   return ngx.redirect(redirect_url)
+
 end
 
 -- Callback Handling

--- a/src/access.lua
+++ b/src/access.lua
@@ -168,10 +168,7 @@ function _M.run(conf)
 	  callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix .. "/oauth2/callback"
 	elseif pl_stringx.endswith(path_prefix, "/oauth2/callback") then --We are in the callback of our proxy
 	  callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix
-    -- ngx.log(ngx.ERR, pl_stringx.split(path_prefix, '/oauth2/callback'))
     handle_callback(conf, callback_url)
-    -- ngx.log(ngx.ERR, "Could not retrieve UserInfo: ", err)
-    -- handle_callback(conf, pl_stringx.split(path_prefix, '/oauth2/callback')[0])
 	else
 	  callback_url = ngx.var.scheme .. "://" .. ngx.var.host .. path_prefix .. "/oauth2/callback"
 	end

--- a/src/access.lua
+++ b/src/access.lua
@@ -67,14 +67,14 @@ end
 
 
 local function validate_roles(conf, token)
-  if token["groups"] == nil then
-    ngx.log(ngx.ERR, 'oidc.userinfo.groups not availble! Check keycloak settings.')
-    return false
-  end
   local _allowed_roles = conf.allowed_roles
   local _next = next(_allowed_roles)
   if _next == nil then
    return true-- no roles provided for checking. Ok.
+  end
+  if token["groups"] == nil then
+    ngx.log(ngx.ERR, 'oidc.userinfo.groups not availble! Check keycloak settings.')
+    return false
   end
   for _, role in pairs(_allowed_roles) do
     if (is_member(role, token["groups"]) == true) then

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -19,6 +19,7 @@ end
 return {
   fields = {
     authorize_url = {type = "url", required = true, func = validate_url},
+    service_logout_url = {type = "string", required = false, default = ""},
     app_login_redirect_url = {type = "string", required = false, default = ""},
     token_url = {type = "url", required = true, func = validate_url},
     user_url  = {type = "url", required = true, func = validate_url},

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -33,6 +33,7 @@ return {
     user_info_periodic_check = {type = "number", required = true, default = 60},
     hosted_domain = {type = "string", default = ""},
     realm = {type = "string", default = ""},
+    allowed_roles = {type = "array", default = {}},
     email_key = {type = "string", default = ""},
     user_info_cache_enabled = {type = "boolean", default = false}
   }

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -32,6 +32,7 @@ return {
     cookie_domain = {type = "string", default = ".company.com"},
     user_info_periodic_check = {type = "number", required = true, default = 60},
     hosted_domain = {type = "string", default = ""},
+    realm = {type = "string", default = ""},
     email_key = {type = "string", default = ""},
     user_info_cache_enabled = {type = "boolean", default = false}
   }


### PR DESCRIPTION
We were looking at he userinfo token for group access and rejecting people even if an endpoint wasn't restricted by group. Changed the order for the proper behavior. 