### PR TITLE
Fix missing client_id as a required field

### DIFF
--- a/src/schema.lua
+++ b/src/schema.lua
@@ -28,6 +28,7 @@ return {
            { app_login_redirect_url = { type = "string", required = false }, },
            { token_url = { type = "string", required = true, custom_validator = validate_url }, },
            { user_url  = {type = "string", required = true, custom_validator = validate_url}, },
+           { client_id = { type = "string", required = true}, },
            { client_secret = { type = "string", required = true}, },
            { scope = { type = "string" }, },
            { salt = { type = "string", required = true, default = "b3253141ce67204b"}, },


### PR DESCRIPTION
Relative to #14 
This pull request includes an update to the `src/schema.lua` file to enhance the configuration schema for OAuth settings. The most important change is the addition of a new required field for `client_id`.

Enhancements to configuration schema:

* [`src/schema.lua`](diffhunk://#diff-d73c7bb4f64ab23f8eae38bd7daaeedab1d4a534b05caf6934005cf835b87ce0R31): Added a new required field `client_id` to the OAuth configuration schema.